### PR TITLE
Reduced gas fees by declaring several functions as 'external'

### DIFF
--- a/token.sol
+++ b/token.sol
@@ -322,7 +322,7 @@ contract Ownable is Context {
    * NOTE: Renouncing ownership will leave the contract without an owner,
    * thereby removing any functionality that is only available to the owner.
    */
-  function renounceOwnership() public onlyOwner {
+  function renounceOwnership() external onlyOwner {
     emit OwnershipTransferred(_owner, address(0));
     _owner = address(0);
   }
@@ -331,7 +331,7 @@ contract Ownable is Context {
    * @dev Transfers ownership of the contract to a new account (`newOwner`).
    * Can only be called by the current owner.
    */
-  function transferOwnership(address newOwner) public onlyOwner {
+  function transferOwnership(address newOwner) external onlyOwner {
     _transferOwnership(newOwner);
   }
 
@@ -476,7 +476,7 @@ contract BFGToken is Context, IBEP20, Ownable {
    *
    * - `spender` cannot be the zero address.
    */
-  function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
+  function increaseAllowance(address spender, uint256 addedValue) external returns (bool) {
     _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
     return true;
   }
@@ -495,7 +495,7 @@ contract BFGToken is Context, IBEP20, Ownable {
    * - `spender` must have allowance for the caller of at least
    * `subtractedValue`.
    */
-  function decreaseAllowance(address spender, uint256 subtractedValue) public returns (bool) {
+  function decreaseAllowance(address spender, uint256 subtractedValue) external returns (bool) {
     _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "BEP20: decreased allowance below zero"));
     return true;
   }
@@ -508,7 +508,7 @@ contract BFGToken is Context, IBEP20, Ownable {
    *
    * - `msg.sender` must be the token owner
    */
-  function mint(uint256 amount) public onlyOwner returns (bool) {
+  function mint(uint256 amount) external onlyOwner returns (bool) {
     _mint(_msgSender(), amount);
     return true;
   }
@@ -516,7 +516,7 @@ contract BFGToken is Context, IBEP20, Ownable {
     /**
    * @dev Burn `amount` tokens and decreasing the total supply.
    */
-  function burn(uint256 amount) public returns (bool) {
+  function burn(uint256 amount) external returns (bool) {
     _burn(_msgSender(), amount);
     return true;
   }


### PR DESCRIPTION
There is an optimization in gas fees by declaring several methods as 'external' instead of 'public'.
In short; Memory allocation is an expensive operation compared to reading memory from calldata. By using 'external' no internal memory is being copied.

More in depth explanation is shown below:
https://ethereum.stackexchange.com/questions/19380/external-vs-public-best-practices